### PR TITLE
Updateing traceur to latest version

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "matteodem:traceur",
-  version: "1.0.0",
+  version: "1.0.1",
   summary: "Javascript next to Javascript of today compiler",
   git: "https://github.com/matteodem/meteor-traceur.git"
 });
@@ -11,5 +11,5 @@ Package._transitional_registerBuildPlugin({
   sources: [
     "plugin/compile-traceur.js"
   ],
-  npmDependencies: {"traceur": "0.0.41"}
+  npmDependencies: {"traceur": "0.0.67"}
 });


### PR DESCRIPTION
Is this possible? Seems like some new features have become stable - such as block scoped variables with let and const.
